### PR TITLE
fix: shell-escape values written to .env.local in Deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,27 +54,30 @@ jobs:
           SEGMENT_PROFILE_KEY: ${{ secrets.SEGMENT_PROFILE_KEY }}
           SEGMENT_TRAIT_CHECK: ${{ vars.SEGMENT_TRAIT_CHECK }}
         run: |
+          write_var() {
+            printf '%s=%q\n' "$1" "${!1}"
+          }
           {
-            echo "TWILIO_ACCOUNT_SID=$TWILIO_ACCOUNT_SID"
-            echo "TWILIO_API_KEY=$TWILIO_API_KEY"
-            echo "TWILIO_API_SECRET=$TWILIO_API_SECRET"
-            echo "TWILIO_AUTH_TOKEN=$TWILIO_AUTH_TOKEN"
-            echo "VERIFY_SERVICE_SID=$VERIFY_SERVICE_SID"
-            echo "SYNC_SERVICE_SID=$SYNC_SERVICE_SID"
-            echo "MESSAGING_SERVICE_SID=$MESSAGING_SERVICE_SID"
-            echo "BASIC_AUTH_USERNAME=$BASIC_AUTH_USERNAME"
-            echo "BASIC_AUTH_PASSWORD=$BASIC_AUTH_PASSWORD"
-            echo "NEXT_PUBLIC_WEDGES=$NEXT_PUBLIC_WEDGES"
-            echo "NEXT_PUBLIC_TWILIO_PHONE_NUMBER=$NEXT_PUBLIC_TWILIO_PHONE_NUMBER"
-            echo "EVENT_NAME=$EVENT_NAME"
-            echo "LEAD_COLLECTION=$LEAD_COLLECTION"
-            echo "OFFERED_PRIZES=$OFFERED_PRIZES"
-            echo "SMALL_PRIZES=$SMALL_PRIZES"
-            echo "TWILIO_CONVERSATION_CONFIGURATION_ID=$TWILIO_CONVERSATION_CONFIGURATION_ID"
-            echo "TWILIO_MEMORY_STORE_ID=$TWILIO_MEMORY_STORE_ID"
-            echo "SEGMENT_SPACE_ID=$SEGMENT_SPACE_ID"
-            echo "SEGMENT_PROFILE_KEY=$SEGMENT_PROFILE_KEY"
-            echo "SEGMENT_TRAIT_CHECK=$SEGMENT_TRAIT_CHECK"
+            write_var TWILIO_ACCOUNT_SID
+            write_var TWILIO_API_KEY
+            write_var TWILIO_API_SECRET
+            write_var TWILIO_AUTH_TOKEN
+            write_var VERIFY_SERVICE_SID
+            write_var SYNC_SERVICE_SID
+            write_var MESSAGING_SERVICE_SID
+            write_var BASIC_AUTH_USERNAME
+            write_var BASIC_AUTH_PASSWORD
+            write_var NEXT_PUBLIC_WEDGES
+            write_var NEXT_PUBLIC_TWILIO_PHONE_NUMBER
+            write_var EVENT_NAME
+            write_var LEAD_COLLECTION
+            write_var OFFERED_PRIZES
+            write_var SMALL_PRIZES
+            write_var TWILIO_CONVERSATION_CONFIGURATION_ID
+            write_var TWILIO_MEMORY_STORE_ID
+            write_var SEGMENT_SPACE_ID
+            write_var SEGMENT_PROFILE_KEY
+            write_var SEGMENT_TRAIT_CHECK
           } > .env.local
 
       - name: Deploy


### PR DESCRIPTION
## Summary
- `deploy.sh` sources `.env.local` as a bash script. Writing values with spaces (e.g. `NEXT_PUBLIC_WEDGES=San Francisco,London,...`) unquoted caused `source` to split them into separate words and try to run the tail as a command (`line 10: Francisco,London,...: command not found`).
- Escapes each value with `printf '%q'` before writing, matching the same technique `deploy.sh` already uses for its own build args.

## Test plan
- [ ] Merge and confirm the Deploy job's "Deploy" step gets past loading `.env.local` without a "command not found" error.