### PR TITLE
Add /settings page backed by Twilio Sync for runtime gameplay config

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -2,16 +2,22 @@ TWILIO_ACCOUNT_SID="ACxxxxx"
 TWILIO_API_KEY="SKxxxxx"
 TWILIO_API_SECRET="xxxxx"
 TWILIO_AUTH_TOKEN="xxxxx"
-EVENT_NAME="DevEvent 2024"
-NEXT_PUBLIC_WEDGES="San Francisco,London,Paris,Madrid,Berlin,New York,Munich,Barcelona,Amsterdam,Vienna"
 NEXT_PUBLIC_TWILIO_PHONE_NUMBER="+4918601860"
 # TWILIO_PHONE_NUMBER is derived automatically from NEXT_PUBLIC_TWILIO_PHONE_NUMBER
 # by deploy.sh — only set this manually if they need to differ
-MAX_BETS_PER_USER="0"
 VERIFY_SERVICE_SID="VAxxxxxxx"
 SYNC_SERVICE_SID="ISxxxxxx"
 BASIC_AUTH_USERNAME="twilio"
 BASIC_AUTH_PASSWORD="admin!"
+
+# The vars below are only the *default* values for gameplay settings. Once an
+# admin saves anything at /settings, the saved value (stored in the Sync
+# "settings" document) takes over and these are ignored until "Reset to
+# environment defaults" is used. See src/app/settings-defaults.ts.
+
+EVENT_NAME="DevEvent 2024"
+NEXT_PUBLIC_WEDGES="San Francisco,London,Paris,Madrid,Berlin,New York,Munich,Barcelona,Amsterdam,Vienna"
+MAX_BETS_PER_USER="0"
 
 # Hide QR code and related elements (defaults to false)
 # Set to "true" to hide the QR code, CTA text, phone number, and QR-related disclaimer

--- a/src/app/api/incoming/helper.ts
+++ b/src/app/api/incoming/helper.ts
@@ -5,23 +5,18 @@ const phoneUtil = PhoneNumberUtil.getInstance();
 
 import twilio, { twiml } from "twilio";
 import i18next from "i18next";
-import { GameState, Player, Stages } from "../../types";
+import { GameState, Player, Settings, Stages } from "../../types";
 import { SyncMapContext } from "twilio/lib/rest/sync/v1/service/syncMap";
 import { DocumentInstance } from "twilio/lib/rest/sync/v1/service/document";
 import { getTemplate } from "@/app/twilio";
+import { settingsFromEnv } from "@/app/settings-defaults";
 
 const en = require("../../../locale/en.json");
 
 const ONE_WEEK = 60 * 60 * 24 * 7;
 export { ONE_WEEK };
 
-const {
-  NEXT_PUBLIC_TWILIO_PHONE_NUMBER = "",
-  NEXT_PUBLIC_WEDGES = "",
-  EVENT_NAME = "",
-} = process.env;
-
-const wedges = NEXT_PUBLIC_WEDGES.split(",");
+const { NEXT_PUBLIC_TWILIO_PHONE_NUMBER = "" } = process.env;
 
 const regexForEmail = /[^@ \t\r\n]+@[^@ \t\r\n]+\.[^@ \t\r\n]+/;
 export { regexForEmail };
@@ -60,6 +55,7 @@ export interface BetsContext {
   betsDoc: DocumentInstance;
   senderID?: string;
   senderName?: string;
+  settings?: Settings;
 }
 
 export async function handleBets(
@@ -69,8 +65,15 @@ export async function handleBets(
   hashedSender: string,
   country: ICountry | undefined,
 ): Promise<string> {
-  const { MAX_BETS_PER_USER = "0" } = process.env;
-  const { messageContent, betsDoc, attendeesMap, senderName, senderID } = ctx;
+  const {
+    messageContent,
+    betsDoc,
+    attendeesMap,
+    senderName,
+    senderID,
+    settings = settingsFromEnv(),
+  } = ctx;
+  const { wedges, maxBetsPerUser, eventName } = settings;
   const twimlRes = new twiml.MessagingResponse();
   const from = `whatsapp:${NEXT_PUBLIC_TWILIO_PHONE_NUMBER}`;
 
@@ -104,8 +107,7 @@ export async function handleBets(
 
     const existingBet = bets.find((bet: any) => bet[0] === hashedSender);
     const maxBetsReached =
-      parseInt(MAX_BETS_PER_USER) > 0 &&
-      currentUser.submittedBets >= parseInt(MAX_BETS_PER_USER);
+      maxBetsPerUser > 0 && currentUser.submittedBets >= maxBetsPerUser;
 
     if (!existingBet && maxBetsReached) {
       twimlRes.message(i18next.t("maxBetsReached"));
@@ -135,7 +137,7 @@ export async function handleBets(
         data: {
           ...currentUser,
           submittedBets: currentUser.submittedBets + 1,
-          event: EVENT_NAME,
+          event: eventName,
         },
       });
     }
@@ -159,8 +161,9 @@ export async function handleBets(
 export async function handleWinnerStages(
   currentUser: Player,
   client: twilio.Twilio,
+  settings: Settings = settingsFromEnv(),
 ): Promise<string> {
-  const { OFFERED_PRIZES } = process.env;
+  const { offeredPrizes: OFFERED_PRIZES } = settings;
   const from = `whatsapp:${NEXT_PUBLIC_TWILIO_PHONE_NUMBER}`;
   const twimlRes = new twiml.MessagingResponse();
 

--- a/src/app/api/incoming/profile-mode.ts
+++ b/src/app/api/incoming/profile-mode.ts
@@ -1,10 +1,11 @@
 import twilio, { twiml } from "twilio";
 import i18next from "i18next";
 import { createHash } from "crypto";
-import { Player, Stages } from "../../types";
+import { Player, Settings, Stages } from "../../types";
 import { SyncMapContext } from "twilio/lib/rest/sync/v1/service/syncMap";
 import { DocumentInstance } from "twilio/lib/rest/sync/v1/service/document";
 import { getTemplate } from "@/app/twilio";
+import { settingsFromEnv } from "@/app/settings-defaults";
 import {
   initI18n,
   handleBets,
@@ -19,7 +20,6 @@ import { checkSegmentTraits } from "./segment";
 
 const {
   VERIFY_SERVICE_SID = "",
-  EVENT_NAME = "",
   NEXT_PUBLIC_TWILIO_PHONE_NUMBER = "",
 } = process.env;
 
@@ -31,6 +31,7 @@ interface ProfileModeContext {
   attendeesMap: SyncMapContext;
   betsDoc: DocumentInstance;
   leadCollection?: string;
+  settings?: Settings;
 }
 
 export async function handleProfileMode(
@@ -44,6 +45,7 @@ export async function handleProfileMode(
     attendeesMap,
     betsDoc,
     leadCollection = "MANUAL",
+    settings = settingsFromEnv(),
   }: ProfileModeContext,
 ): Promise<string> {
   const twimlRes = new twiml.MessagingResponse();
@@ -54,14 +56,14 @@ export async function handleProfileMode(
     .update(currentUser?.sender || senderID || "")
     .digest("hex");
 
-  const ctx = { senderName, senderID, recipient, messageContent, attendeesMap, betsDoc };
+  const ctx = { senderName, senderID, recipient, messageContent, attendeesMap, betsDoc, settings };
 
   try {
     if (leadCollection === "NONE") {
       return handleNoneMode(
         currentUser,
         client,
-        { senderName, senderID, recipient, messageContent, attendeesMap, betsDoc },
+        { senderName, senderID, recipient, messageContent, attendeesMap, betsDoc, settings },
         { from, country, hashedSender, twimlRes },
       );
     }
@@ -106,7 +108,7 @@ export async function handleProfileMode(
               to: matchedEmail[0].toLowerCase(),
               channel: "email",
               channelConfiguration: {
-                substitutions: { "event-name": EVENT_NAME },
+                substitutions: { "event-name": settings.eventName },
               },
             });
           await attendeesMap.syncMapItems(hashedSender).update({
@@ -170,7 +172,7 @@ export async function handleProfileMode(
       currentUser.stage === Stages.WINNER_CLAIMED ||
       currentUser.stage === Stages.RAFFLE_WINNER
     ) {
-      return handleWinnerStages(currentUser, client);
+      return handleWinnerStages(currentUser, client, settings);
     } else {
       await client.messages.create({
         body: i18next.t("catchAllError"),
@@ -196,7 +198,15 @@ export async function handleProfileMode(
 async function handleNoneMode(
   currentUser: Player | undefined,
   client: twilio.Twilio,
-  { senderName, senderID, recipient, messageContent, attendeesMap, betsDoc }: ProfileModeContext,
+  {
+    senderName,
+    senderID,
+    recipient,
+    messageContent,
+    attendeesMap,
+    betsDoc,
+    settings = settingsFromEnv(),
+  }: ProfileModeContext,
   {
     from,
     country,
@@ -209,7 +219,15 @@ async function handleNoneMode(
     twimlRes: twiml.MessagingResponse;
   },
 ): Promise<string> {
-  const ctx = { senderName, senderID, recipient: recipient!, messageContent, attendeesMap: attendeesMap!, betsDoc: betsDoc! };
+  const ctx = {
+    senderName,
+    senderID,
+    recipient: recipient!,
+    messageContent,
+    attendeesMap: attendeesMap!,
+    betsDoc: betsDoc!,
+    settings,
+  };
 
   if (!currentUser) {
     await attendeesMap!.syncMapItems.create({
@@ -243,7 +261,7 @@ async function handleNoneMode(
     currentUser.stage === Stages.WINNER_CLAIMED ||
     currentUser.stage === Stages.RAFFLE_WINNER
   ) {
-    return handleWinnerStages(currentUser, client);
+    return handleWinnerStages(currentUser, client, settings);
   }
 
   return handleBets(currentUser, client, ctx, hashedSender, country);

--- a/src/app/api/incoming/qr-mode.ts
+++ b/src/app/api/incoming/qr-mode.ts
@@ -2,10 +2,11 @@ import twilio, { twiml } from "twilio";
 import i18next from "i18next";
 import { createHash } from "crypto";
 import type { MemoryClient, TACConfig } from "twilio-agent-connect";
-import { Player, Stages } from "../../types";
+import { Player, Settings, Stages } from "../../types";
 import { SyncMapContext } from "twilio/lib/rest/sync/v1/service/syncMap";
 import { DocumentInstance } from "twilio/lib/rest/sync/v1/service/document";
 import { getTemplate } from "@/app/twilio";
+import { settingsFromEnv } from "@/app/settings-defaults";
 import {
   initI18n,
   handleBets,
@@ -88,6 +89,7 @@ export async function handleQrMode(
     betsDoc,
     numMedia,
     mediaUrl,
+    settings = settingsFromEnv(),
   }: {
     senderName?: string;
     senderID?: string;
@@ -97,6 +99,7 @@ export async function handleQrMode(
     betsDoc: DocumentInstance;
     numMedia: number;
     mediaUrl?: string;
+    settings?: Settings;
   },
 ): Promise<string> {
   const twimlRes = new twiml.MessagingResponse();
@@ -110,7 +113,7 @@ export async function handleQrMode(
     .update(currentUser?.sender || senderID || "")
     .digest("hex");
 
-  const ctx = { senderName, senderID, recipient, messageContent, attendeesMap, betsDoc };
+  const ctx = { senderName, senderID, recipient, messageContent, attendeesMap, betsDoc, settings };
 
   // Already registered — handle bets / winner stages
   if (currentUser?.stage === Stages.VERIFIED_USER) {
@@ -122,7 +125,7 @@ export async function handleQrMode(
     currentUser?.stage === Stages.WINNER_CLAIMED ||
     currentUser?.stage === Stages.RAFFLE_WINNER
   ) {
-    return handleWinnerStages(currentUser, client);
+    return handleWinnerStages(currentUser, client, settings);
   }
 
   // Not yet registered — check if Memory profile exists

--- a/src/app/api/incoming/route.ts
+++ b/src/app/api/incoming/route.ts
@@ -5,9 +5,10 @@ import { handleProfileMode } from "./profile-mode";
 import { handleQrMode } from "./qr-mode";
 import { deleteMemoryProfile } from "./memory";
 import { createHash } from "crypto";
-import { Player } from "../../types";
+import { Player, Settings } from "../../types";
 import { SyncMapContext } from "twilio/lib/rest/sync/v1/service/syncMap";
 import { DocumentInstance } from "twilio/lib/rest/sync/v1/service/document";
+import { getSettings } from "../../settings";
 
 export const maxDuration = 30;
 
@@ -16,10 +17,7 @@ const {
   TWILIO_API_SECRET = "",
   TWILIO_ACCOUNT_SID = "",
   SYNC_SERVICE_SID = "",
-  NEXT_PUBLIC_WEDGES = "",
 } = process.env;
-
-const wedges = NEXT_PUBLIC_WEDGES.split(",");
 
 async function getUser(attendeesMap: SyncMapContext, hashedSender: string) {
   let currentUser: Player | undefined;
@@ -32,7 +30,11 @@ async function getUser(attendeesMap: SyncMapContext, hashedSender: string) {
   return currentUser;
 }
 
-async function addDemoBet(betsDoc: DocumentInstance, messageContent: string) {
+async function addDemoBet(
+  betsDoc: DocumentInstance,
+  messageContent: string,
+  wedges: string[],
+) {
   if (process.env.demoBet) {
     const bets = betsDoc.data.bets || [];
     bets.push([
@@ -51,8 +53,9 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  // Read at request time so env changes take effect without a restart
-  const LEAD_COLLECTION = process.env.LEAD_COLLECTION ?? "MANUAL";
+  // Read at request time so settings changes take effect without a restart
+  const settings: Settings = await getSettings();
+  const LEAD_COLLECTION = settings.leadCollection;
 
   const client = twilio(TWILIO_API_KEY, TWILIO_API_SECRET, { accountSid: TWILIO_ACCOUNT_SID });
   const syncService = await client.sync.v1.services(SYNC_SERVICE_SID).fetch();
@@ -71,7 +74,7 @@ export async function POST(req: NextRequest) {
   const hashedSender = createHash("sha256").update(senderID).digest("hex");
   const currentUser = await getUser(attendeesMap, hashedSender);
 
-  process.env.demoBet && (await addDemoBet(betsDoc, messageContent));
+  process.env.demoBet && (await addDemoBet(betsDoc, messageContent, settings.wedges));
 
   let response = "";
 
@@ -104,6 +107,7 @@ export async function POST(req: NextRequest) {
       betsDoc,
       numMedia,
       mediaUrl: mediaUrl ?? undefined,
+      settings,
     });
   } else {
     // LEAD_COLLECTION === "MANUAL" or "NONE"
@@ -115,6 +119,7 @@ export async function POST(req: NextRequest) {
       attendeesMap,
       betsDoc,
       leadCollection: LEAD_COLLECTION,
+      settings,
     });
   }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,10 +30,17 @@ function App() {
   const [gameState, setGameState] = useState<GameState>(GameState.RUNNING);
   const screenOrientation = useScreenOrientation();
 
-  let wedges = (process.env.NEXT_PUBLIC_WEDGES || "").split(",");
-  const hideQrCode = process.env.NEXT_PUBLIC_HIDE_QR_CODE === "true";
-  const prizesPerField = parseInt(
-    process.env.NEXT_PUBLIC_PRIZES_PER_FIELD || "0",
+  // process.env.NEXT_PUBLIC_* is inlined at build time, so these only serve
+  // as the initial defaults — the settings Sync doc subscription below
+  // overrides them live when an admin has saved settings at /settings.
+  const [wedges, setWedges] = useState<string[]>(() =>
+    (process.env.NEXT_PUBLIC_WEDGES || "").split(","),
+  );
+  const [hideQrCode, setHideQrCode] = useState(
+    () => process.env.NEXT_PUBLIC_HIDE_QR_CODE === "true",
+  );
+  const [prizesPerField, setPrizesPerField] = useState(() =>
+    parseInt(process.env.NEXT_PUBLIC_PRIZES_PER_FIELD || "0"),
   );
 
   useEffect(() => {
@@ -49,7 +56,10 @@ function App() {
       });
       syncClient.on("connectionStateChanged", async (state: string) => {
         if (state === "connected") {
-          const doc: any = await syncClient.document("bets");
+          const [doc, settingsDoc]: any[] = await Promise.all([
+            syncClient.document("bets"),
+            syncClient.document("settings"),
+          ]);
           doc.on("updated", (event: any) => {
             if (event.data.bets) setBets(event.data.bets);
             setIsFull(event?.data?.full || false);
@@ -63,6 +73,14 @@ function App() {
             setPrizeWins(doc.data.prizeWins || {});
             setGameState(doc.data.gameState || GameState.RUNNING);
           }
+
+          const applySettings = (data: any) => {
+            if (data?.wedges) setWedges(data.wedges);
+            if (data?.hideQrCode !== undefined) setHideQrCode(data.hideQrCode);
+            if (data?.prizesPerField !== undefined) setPrizesPerField(data.prizesPerField);
+          };
+          settingsDoc.on("updated", (event: any) => applySettings(event.data));
+          applySettings(settingsDoc.data);
         }
       });
     });

--- a/src/app/settings-defaults.ts
+++ b/src/app/settings-defaults.ts
@@ -1,0 +1,41 @@
+import { Settings } from "./types";
+
+function toCsvList(value: string | undefined): string[] {
+  return (value || "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry !== "");
+}
+
+// Reads process.env at call time (not module load time) so changes to
+// .env.local / deployment env vars take effect without a restart, matching
+// the rest of the app's "read at request time" convention.
+export function settingsFromEnv(): Settings {
+  return {
+    wedges: toCsvList(process.env.NEXT_PUBLIC_WEDGES),
+    eventName: process.env.EVENT_NAME || "",
+    hideQrCode: process.env.NEXT_PUBLIC_HIDE_QR_CODE === "true",
+    prizesPerField: parseInt(process.env.NEXT_PUBLIC_PRIZES_PER_FIELD || "0", 10) || 0,
+    offeredPrizes: (process.env.OFFERED_PRIZES || "") as Settings["offeredPrizes"],
+    smallPrizes: toCsvList(process.env.SMALL_PRIZES),
+    leadCollection: (process.env.LEAD_COLLECTION || "MANUAL") as Settings["leadCollection"],
+    maxBetsPerUser: parseInt(process.env.MAX_BETS_PER_USER || "0", 10) || 0,
+  };
+}
+
+export function mergeSettings(
+  defaults: Settings,
+  overrides?: Partial<Settings> | null,
+): Settings {
+  if (!overrides) return defaults;
+  return {
+    wedges: overrides.wedges ?? defaults.wedges,
+    eventName: overrides.eventName ?? defaults.eventName,
+    hideQrCode: overrides.hideQrCode ?? defaults.hideQrCode,
+    prizesPerField: overrides.prizesPerField ?? defaults.prizesPerField,
+    offeredPrizes: overrides.offeredPrizes ?? defaults.offeredPrizes,
+    smallPrizes: overrides.smallPrizes ?? defaults.smallPrizes,
+    leadCollection: overrides.leadCollection ?? defaults.leadCollection,
+    maxBetsPerUser: overrides.maxBetsPerUser ?? defaults.maxBetsPerUser,
+  };
+}

--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -1,0 +1,85 @@
+"use server";
+
+import { Settings } from "./types";
+import { settingsFromEnv, mergeSettings } from "./settings-defaults";
+
+const {
+  TWILIO_API_KEY = "",
+  TWILIO_API_SECRET = "",
+  TWILIO_ACCOUNT_SID = "",
+  SYNC_SERVICE_SID = "",
+} = process.env;
+
+const client = require("twilio")(TWILIO_API_KEY, TWILIO_API_SECRET, {
+  accountSid: TWILIO_ACCOUNT_SID,
+});
+
+enum Privilege {
+  FRONTEND = "FRONTEND",
+}
+
+// Unconditionally (re)grants FRONTEND read access, so a doc that was
+// auto-created here before this permission grant existed self-heals on the
+// next call, without requiring a re-run of `pnpm setup`.
+async function ensureSettingsDocExists(syncService: any) {
+  const doc = syncService.documents()("settings");
+  try {
+    await doc.fetch();
+  } catch (e: any) {
+    if (e.status !== 404) throw e;
+    await syncService.documents().create({ uniqueName: "settings" });
+  }
+  await doc.documentPermissions(Privilege.FRONTEND).update({
+    read: true,
+    write: false,
+    manage: false,
+  });
+  return doc;
+}
+
+export async function getSettings(): Promise<Settings> {
+  const syncService = await client.sync.v1.services(SYNC_SERVICE_SID).fetch();
+  const doc = await ensureSettingsDocExists(syncService);
+  const fetched = await doc.fetch();
+  return mergeSettings(settingsFromEnv(), fetched.data as Partial<Settings>);
+}
+
+function assertValidSettings(settings: Settings) {
+  if (settings.wedges.length === 0) {
+    throw new Error("At least one wedge is required");
+  }
+  if (!["MANUAL", "QR", "NONE"].includes(settings.leadCollection)) {
+    throw new Error("Invalid lead collection mode");
+  }
+  if (!["", "small", "big", "both"].includes(settings.offeredPrizes)) {
+    throw new Error("Invalid offered prizes value");
+  }
+  if (settings.prizesPerField < 0) {
+    throw new Error("Prizes per field cannot be negative");
+  }
+  if (settings.maxBetsPerUser < 0) {
+    throw new Error("Max bets per user cannot be negative");
+  }
+}
+
+export async function saveSettings(settings: Settings): Promise<Settings> {
+  const cleaned: Settings = {
+    ...settings,
+    wedges: settings.wedges.map((w) => w.trim()).filter((w) => w !== ""),
+    smallPrizes: settings.smallPrizes.map((p) => p.trim()).filter((p) => p !== ""),
+    eventName: settings.eventName.trim(),
+  };
+  assertValidSettings(cleaned);
+
+  const syncService = await client.sync.v1.services(SYNC_SERVICE_SID).fetch();
+  const doc = await ensureSettingsDocExists(syncService);
+  await doc.update({ data: cleaned });
+  return cleaned;
+}
+
+export async function resetSettings(): Promise<Settings> {
+  const syncService = await client.sync.v1.services(SYNC_SERVICE_SID).fetch();
+  const doc = await ensureSettingsDocExists(syncService);
+  await doc.update({ data: {} });
+  return settingsFromEnv();
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,30 @@
+export const dynamic = "force-dynamic";
+
+import { getSettings } from "../settings";
+import { SettingsForm } from "./settings-form";
+import { displayFont } from "../fonts";
+
+export default async function SettingsPage() {
+  const settings = await getSettings();
+
+  return (
+    <div className="h-full overflow-auto relative">
+      <div className="mx-4 sm:mx-6 py-8 flex flex-col gap-6 max-w-2xl">
+        <header>
+          <h1
+            className={`text-3xl sm:text-4xl text-[#FDF7F4] ${displayFont.className}`}
+          >
+            Event settings
+          </h1>
+          <p className="mt-1 text-sm text-[#B9C3D9]">
+            Overrides saved here take effect immediately, without a redeploy.
+            Leave a field untouched to keep using its environment variable
+            default.
+          </p>
+        </header>
+
+        <SettingsForm initial={settings} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/settings/settings-form.tsx
+++ b/src/app/settings/settings-form.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { saveSettings, resetSettings } from "../settings";
+import { Settings } from "../types";
+
+const toggleItemClassName =
+  "border border-[#24365F] bg-[#0B1B3E] text-[#B9C3D9] hover:bg-[#12275A] hover:text-[#FDF7F4] data-[state=on]:bg-[#EF223A] data-[state=on]:text-[#FDF7F4]";
+
+const LEAD_COLLECTION_OPTIONS: { value: Settings["leadCollection"]; label: string }[] = [
+  { value: "MANUAL", label: "Manual (name + email + OTP)" },
+  { value: "QR", label: "QR badge scan" },
+  { value: "NONE", label: "None" },
+];
+
+// Radix ToggleGroup reports "" both when a real option has value="" and when
+// the pressed item is clicked again to deselect it — those two cases are
+// indistinguishable. Use a non-empty sentinel for "None" and translate at
+// the read/write boundary instead.
+type OfferedPrizesUiValue = "none" | "small" | "big" | "both";
+
+const OFFERED_PRIZES_OPTIONS: { value: OfferedPrizesUiValue; label: string }[] = [
+  { value: "none", label: "None" },
+  { value: "small", label: "Small prize" },
+  { value: "big", label: "Raffle" },
+  { value: "both", label: "Both" },
+];
+
+function toUiOfferedPrizes(value: Settings["offeredPrizes"]): OfferedPrizesUiValue {
+  return value === "" ? "none" : value;
+}
+
+function fromUiOfferedPrizes(value: OfferedPrizesUiValue): Settings["offeredPrizes"] {
+  return value === "none" ? "" : value;
+}
+
+function fieldLabelClassName() {
+  return "text-xs uppercase tracking-[0.15em] text-[#7C89AC]";
+}
+
+export function SettingsForm({ initial }: { initial: Settings }) {
+  const [wedgesText, setWedgesText] = useState(initial.wedges.join(", "));
+  const [eventName, setEventName] = useState(initial.eventName);
+  const [hideQrCode, setHideQrCode] = useState(initial.hideQrCode);
+  const [prizesPerField, setPrizesPerField] = useState(initial.prizesPerField);
+  const [offeredPrizes, setOfferedPrizes] = useState<OfferedPrizesUiValue>(
+    toUiOfferedPrizes(initial.offeredPrizes),
+  );
+  const [smallPrizesText, setSmallPrizesText] = useState(initial.smallPrizes.join(", "));
+  const [leadCollection, setLeadCollection] = useState(initial.leadCollection);
+  const [maxBetsPerUser, setMaxBetsPerUser] = useState(initial.maxBetsPerUser);
+
+  const [status, setStatus] = useState<
+    { kind: "idle" } | { kind: "saving" } | { kind: "saved" } | { kind: "error"; message: string }
+  >({ kind: "idle" });
+  const [isPending, startTransition] = useTransition();
+
+  const wedgeCount = wedgesText
+    .split(",")
+    .map((w) => w.trim())
+    .filter((w) => w !== "").length;
+
+  function handleSave() {
+    setStatus({ kind: "saving" });
+    const settings: Settings = {
+      wedges: wedgesText.split(","),
+      eventName,
+      hideQrCode,
+      prizesPerField,
+      offeredPrizes: fromUiOfferedPrizes(offeredPrizes),
+      smallPrizes: smallPrizesText.split(","),
+      leadCollection,
+      maxBetsPerUser,
+    };
+    startTransition(async () => {
+      try {
+        const saved = await saveSettings(settings);
+        setWedgesText(saved.wedges.join(", "));
+        setSmallPrizesText(saved.smallPrizes.join(", "));
+        setStatus({ kind: "saved" });
+      } catch (e: any) {
+        setStatus({ kind: "error", message: e.message || "Failed to save settings" });
+      }
+    });
+  }
+
+  function handleReset() {
+    setStatus({ kind: "saving" });
+    startTransition(async () => {
+      try {
+        const defaults = await resetSettings();
+        setWedgesText(defaults.wedges.join(", "));
+        setEventName(defaults.eventName);
+        setHideQrCode(defaults.hideQrCode);
+        setPrizesPerField(defaults.prizesPerField);
+        setOfferedPrizes(toUiOfferedPrizes(defaults.offeredPrizes));
+        setSmallPrizesText(defaults.smallPrizes.join(", "));
+        setLeadCollection(defaults.leadCollection);
+        setMaxBetsPerUser(defaults.maxBetsPerUser);
+        setStatus({ kind: "saved" });
+      } catch (e: any) {
+        setStatus({ kind: "error", message: e.message || "Failed to reset settings" });
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <label className={fieldLabelClassName()}>Event name</label>
+        <Input value={eventName} onChange={(e) => setEventName(e.target.value)} />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className={fieldLabelClassName()}>
+          Wedges &middot; {wedgeCount} configured
+        </label>
+        <Textarea
+          value={wedgesText}
+          onChange={(e) => setWedgesText(e.target.value)}
+          placeholder="San Francisco, London, Paris, ..."
+        />
+        <p className="text-xs text-[#7C89AC]">8 wedges recommended for a balanced wheel.</p>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className={fieldLabelClassName()}>Lead collection mode</label>
+        <ToggleGroup
+          type="single"
+          value={leadCollection}
+          onValueChange={(value) => value && setLeadCollection(value as Settings["leadCollection"])}
+        >
+          {LEAD_COLLECTION_OPTIONS.map((option) => (
+            <ToggleGroupItem
+              key={option.value}
+              value={option.value}
+              aria-label={option.label}
+              className={toggleItemClassName}
+            >
+              {option.label}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className={fieldLabelClassName()}>Offered prizes</label>
+        <ToggleGroup
+          type="single"
+          value={offeredPrizes}
+          onValueChange={(value) => value && setOfferedPrizes(value as OfferedPrizesUiValue)}
+        >
+          {OFFERED_PRIZES_OPTIONS.map((option) => (
+            <ToggleGroupItem
+              key={option.value}
+              value={option.value}
+              aria-label={option.label}
+              className={toggleItemClassName}
+            >
+              {option.label}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className={fieldLabelClassName()}>Small prize pool</label>
+        <Textarea
+          value={smallPrizesText}
+          onChange={(e) => setSmallPrizesText(e.target.value)}
+          placeholder="Twilio Sticker Pack, ..."
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-6">
+        <div className="flex flex-col gap-2">
+          <label className={fieldLabelClassName()}>Prizes per wedge &middot; 0 = unlimited</label>
+          <Input
+            type="number"
+            min={0}
+            value={prizesPerField}
+            onChange={(e) => setPrizesPerField(parseInt(e.target.value || "0", 10))}
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <label className={fieldLabelClassName()}>Max bets per user &middot; 0 = unlimited</label>
+          <Input
+            type="number"
+            min={0}
+            value={maxBetsPerUser}
+            onChange={(e) => setMaxBetsPerUser(parseInt(e.target.value || "0", 10))}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className={fieldLabelClassName()}>QR code on wheel screen</label>
+        <ToggleGroup
+          type="single"
+          value={hideQrCode ? "hide" : "show"}
+          onValueChange={(value) => value && setHideQrCode(value === "hide")}
+        >
+          <ToggleGroupItem value="show" aria-label="Show" className={toggleItemClassName}>
+            Show
+          </ToggleGroupItem>
+          <ToggleGroupItem value="hide" aria-label="Hide" className={toggleItemClassName}>
+            Hide
+          </ToggleGroupItem>
+        </ToggleGroup>
+      </div>
+
+      <div className="flex items-center gap-3 pt-2">
+        <Button
+          onClick={handleSave}
+          disabled={isPending}
+          className="bg-[#EF223A] text-[#FDF7F4] hover:bg-[#EF223A]/90"
+        >
+          Save changes
+        </Button>
+        <Button
+          onClick={handleReset}
+          disabled={isPending}
+          variant="outline"
+          className="border-[#24365F] bg-[#0B1B3E] text-[#B9C3D9] hover:bg-[#12275A] hover:text-[#FDF7F4]"
+        >
+          Reset to environment defaults
+        </Button>
+
+        {status.kind === "saving" && <span className="text-sm text-[#B9C3D9]">Saving…</span>}
+        {status.kind === "saved" && <span className="text-sm text-[#7CFFB2]">Saved</span>}
+        {status.kind === "error" && (
+          <span className="text-sm text-[#EF223A]">{status.message}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/twilio.ts
+++ b/src/app/twilio.ts
@@ -8,6 +8,7 @@ import { GameState, Stages } from "./types";
 import { maskNumber } from "./util";
 import axios from "axios";
 import { TEMPLATE_PREFIX } from "@/scripts/contentTemplates";
+import { getSettings } from "./settings";
 
 const en = require("../locale/en.json");
 
@@ -85,14 +86,12 @@ export async function tempUnlockGame() {
 }
 
 export async function initializePrizeWins() {
-  const { NEXT_PUBLIC_WEDGES, NEXT_PUBLIC_PRIZES_PER_FIELD } = process.env;
-  const prizesPerField = parseInt(NEXT_PUBLIC_PRIZES_PER_FIELD || "0");
+  const { wedges, prizesPerField } = await getSettings();
 
   if (prizesPerField <= 0) {
     return; // No prize tracking needed
   }
 
-  const wedges = (NEXT_PUBLIC_WEDGES || "").split(",");
   const syncService = await client.sync.v1.services(SYNC_SERVICE_SID).fetch();
   const betsDoc = await syncService.documents()("bets").fetch();
 
@@ -161,7 +160,7 @@ export interface StatsSummary {
 }
 
 export async function getStats(): Promise<StatsSummary> {
-  const wedges = (process.env.NEXT_PUBLIC_WEDGES || "").split(",");
+  const { wedges } = await getSettings();
   const syncService = await client.sync.v1.services(SYNC_SERVICE_SID).fetch();
   const betsDoc = await syncService.documents()("bets").fetch();
   const statsDoc = await syncService.documents()("stats").fetch();
@@ -310,14 +309,8 @@ export async function notifyAndUpdateWinners(winners: any[]) {
   const attendeesMap = syncService.syncMaps()("attendees");
   const betsDoc = await syncService.documents()("bets").fetch();
 
-  const { OFFERED_PRIZES, SMALL_PRIZES, NEXT_PUBLIC_PRIZES_PER_FIELD } =
-    process.env;
-  const prizesPerField = parseInt(NEXT_PUBLIC_PRIZES_PER_FIELD || "0");
-
-  const availablePrizes =
-    SMALL_PRIZES?.split(",")
-      .map((prize) => prize.trim())
-      .filter((prize) => prize !== "") || [];
+  const { offeredPrizes: OFFERED_PRIZES, smallPrizes: availablePrizes, prizesPerField } =
+    await getSettings();
 
   // Check if prizes are available for the winning field
   let prizesAvailable = true;
@@ -488,7 +481,7 @@ export async function sendRaffleWinnerMessage(to: string) {
 export async function messageOthers(unluckyBets: any[], winningWedge: string) {
   const syncService = await client.sync.v1.services(SYNC_SERVICE_SID).fetch();
   const attendeesMap = syncService.syncMaps()("attendees");
-  const { MAX_BETS_PER_USER = "0" } = process.env;
+  const { maxBetsPerUser } = await getSettings();
 
   await Promise.all(
     unluckyBets.map(async (unluckyBet) => {
@@ -497,8 +490,8 @@ export async function messageOthers(unluckyBets: any[], winningWedge: string) {
           .syncMapItems(unluckyBet[0])
           .fetch();
         const hasMoreBetsLeft =
-          parseInt(MAX_BETS_PER_USER) === 0 ||
-          unluckyPlayer.data?.submittedBets + 1 <= parseInt(MAX_BETS_PER_USER);
+          maxBetsPerUser === 0 ||
+          unluckyPlayer.data?.submittedBets + 1 <= maxBetsPerUser;
 
         const body = await localizeStringForPhoneNumber(
           hasMoreBetsLeft ? "loserHasMoreTries" : "loserLastTry",
@@ -569,7 +562,7 @@ export async function getTemplate(name: string, language?: string) {
 }
 
 export const raffleWinner = async () => {
-  const { OFFERED_PRIZES } = process.env;
+  const { offeredPrizes: OFFERED_PRIZES } = await getSettings();
   if (OFFERED_PRIZES !== "big" && OFFERED_PRIZES !== "both") {
     console.log("No raffle prize offered");
     return {

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -27,3 +27,14 @@ export interface Player {
   foundInSegment?: boolean;
   [key: string]: unknown;
 }
+
+export interface Settings {
+  wedges: string[];
+  eventName: string;
+  hideQrCode: boolean;
+  prizesPerField: number;
+  offeredPrizes: "" | "small" | "big" | "both";
+  smallPrizes: string[];
+  leadCollection: "MANUAL" | "QR" | "NONE";
+  maxBetsPerUser: number;
+}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-20 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -44,5 +44,5 @@ function isAuthenticated(req: NextRequest) {
 
 // Step 3. Configure "Matching Paths" below to protect routes with HTTP Basic Auth
 export const config = {
-  matcher: ["/", "/admin", "/stats"],
+  matcher: ["/", "/admin", "/stats", "/settings"],
 };

--- a/src/scripts/setup.ts
+++ b/src/scripts/setup.ts
@@ -40,6 +40,7 @@ const client = twilio(TWILIO_API_KEY, TWILIO_API_SECRET, {
 
   await createSyncDocIfNotExists("bets");
   await createSyncDocIfNotExists("stats");
+  await createSyncDocIfNotExists("settings");
   await createSyncMapIfNotExists("attendees");
 
   // Initialize prize wins tracking if NEXT_PUBLIC_PRIZES_PER_FIELD is set

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+const { BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD } = process.env;
+
+// Read-only: these tests must never click "Save changes" or "Reset to
+// environment defaults" — that would persist to the real Sync "settings"
+// document and could make other specs (e.g. home.spec.ts, which asserts the
+// wheel against NEXT_PUBLIC_WEDGES directly) flaky or wrong.
+
+test("See settings page pre-filled from environment defaults", async ({
+  page,
+}) => {
+  await page.goto(
+    `http://${BASIC_AUTH_USERNAME}:${BASIC_AUTH_PASSWORD}@localhost:3000/settings`,
+  );
+
+  await expect(page.getByRole("heading", { name: "Event settings" })).toBeVisible();
+
+  const wedges = (process.env.NEXT_PUBLIC_WEDGES || "")
+    .split(",")
+    .map((w) => w.trim())
+    .filter((w) => w !== "");
+
+  await expect(page.getByText(`Wedges · ${wedges.length} configured`)).toBeVisible();
+  await expect(page.getByText("8 wedges recommended for a balanced wheel.")).toBeVisible();
+
+  await expect(
+    page.getByRole("button", { name: "Save changes" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Reset to environment defaults" }),
+  ).toBeVisible();
+});
+
+test("Don't see the settings page as unauthenticated user", async ({ page }) => {
+  const response = await page.goto("http://localhost:3000/settings");
+
+  if (!response) {
+    throw new Error("No response");
+  }
+
+  await expect(response.status()).toBe(401);
+});

--- a/tests/vitest/settings.test.ts
+++ b/tests/vitest/settings.test.ts
@@ -1,0 +1,232 @@
+import { expect, test, describe, vi, afterEach } from "vitest";
+
+// Mock twilio.ts before any imports that pull it in, to prevent jwa/AccessToken
+// from crashing in jsdom (Buffer not available at module evaluation time) —
+// same guard responses.test.tsx uses.
+vi.mock("@/app/twilio", () => ({
+  getTemplate: async () => ({ sid: "HXmock" }),
+  getAllTemplates: async () => [],
+}));
+
+import { settingsFromEnv, mergeSettings } from "@/app/settings-defaults";
+import { handleProfileMode } from "@/app/api/incoming/profile-mode";
+import { Settings, Stages } from "@/app/types";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("settingsFromEnv", () => {
+  test("returns env-free defaults when nothing is set", () => {
+    vi.stubEnv("NEXT_PUBLIC_WEDGES", "");
+    vi.stubEnv("EVENT_NAME", "");
+    vi.stubEnv("NEXT_PUBLIC_HIDE_QR_CODE", "");
+    vi.stubEnv("NEXT_PUBLIC_PRIZES_PER_FIELD", "");
+    vi.stubEnv("OFFERED_PRIZES", "");
+    vi.stubEnv("SMALL_PRIZES", "");
+    vi.stubEnv("LEAD_COLLECTION", "");
+    vi.stubEnv("MAX_BETS_PER_USER", "");
+
+    expect(settingsFromEnv()).toEqual({
+      wedges: [],
+      eventName: "",
+      hideQrCode: false,
+      prizesPerField: 0,
+      offeredPrizes: "",
+      smallPrizes: [],
+      leadCollection: "MANUAL",
+      maxBetsPerUser: 0,
+    });
+  });
+
+  test("parses CSV lists, trimming whitespace and dropping empty entries", () => {
+    vi.stubEnv("NEXT_PUBLIC_WEDGES", "Java, Python ,, JavaScript");
+    vi.stubEnv("SMALL_PRIZES", " Sticker Pack ,Tote Bag,");
+
+    const settings = settingsFromEnv();
+    expect(settings.wedges).toEqual(["Java", "Python", "JavaScript"]);
+    expect(settings.smallPrizes).toEqual(["Sticker Pack", "Tote Bag"]);
+  });
+
+  test("parses booleans and numbers", () => {
+    vi.stubEnv("NEXT_PUBLIC_HIDE_QR_CODE", "true");
+    vi.stubEnv("NEXT_PUBLIC_PRIZES_PER_FIELD", "5");
+    vi.stubEnv("MAX_BETS_PER_USER", "3");
+
+    const settings = settingsFromEnv();
+    expect(settings.hideQrCode).toBe(true);
+    expect(settings.prizesPerField).toBe(5);
+    expect(settings.maxBetsPerUser).toBe(3);
+  });
+
+  test("falls back to 0 for non-numeric values instead of NaN", () => {
+    vi.stubEnv("NEXT_PUBLIC_PRIZES_PER_FIELD", "not-a-number");
+    vi.stubEnv("MAX_BETS_PER_USER", "not-a-number");
+
+    const settings = settingsFromEnv();
+    expect(settings.prizesPerField).toBe(0);
+    expect(settings.maxBetsPerUser).toBe(0);
+  });
+
+  test("defaults leadCollection to MANUAL when unset", () => {
+    vi.stubEnv("LEAD_COLLECTION", "");
+    expect(settingsFromEnv().leadCollection).toBe("MANUAL");
+  });
+});
+
+describe("mergeSettings", () => {
+  const defaults: Settings = {
+    wedges: ["Java", "Python"],
+    eventName: "Default Event",
+    hideQrCode: false,
+    prizesPerField: 5,
+    offeredPrizes: "small",
+    smallPrizes: ["Sticker"],
+    leadCollection: "MANUAL",
+    maxBetsPerUser: 3,
+  };
+
+  test("returns the defaults untouched when there are no overrides", () => {
+    expect(mergeSettings(defaults, undefined)).toEqual(defaults);
+    expect(mergeSettings(defaults, null)).toEqual(defaults);
+    expect(mergeSettings(defaults, {})).toEqual(defaults);
+  });
+
+  test("prefers override fields over defaults, field by field", () => {
+    const merged = mergeSettings(defaults, {
+      eventName: "Override Event",
+      leadCollection: "QR",
+    });
+    expect(merged.eventName).toBe("Override Event");
+    expect(merged.leadCollection).toBe("QR");
+    // Untouched fields keep the default
+    expect(merged.wedges).toEqual(defaults.wedges);
+    expect(merged.prizesPerField).toBe(defaults.prizesPerField);
+  });
+
+  test("respects an explicit 0 override instead of falling back to a non-zero default", () => {
+    const merged = mergeSettings(defaults, { prizesPerField: 0, maxBetsPerUser: 0 });
+    expect(merged.prizesPerField).toBe(0);
+    expect(merged.maxBetsPerUser).toBe(0);
+  });
+});
+
+// Alias matching the one in responses.test.tsx, so these read the same way.
+const generateResponse = (user: any, client: any, ctx: any) =>
+  handleProfileMode(user, client, {
+    ...ctx,
+    leadCollection: ctx.settings?.leadCollection ?? "MANUAL",
+  });
+
+describe("Sync-sourced settings override env vars", () => {
+  test("a wedge only present in ctx.settings.wedges (not in env) is accepted", async () => {
+    // NEXT_PUBLIC_WEDGES doesn't contain "Rust" — only the settings override does.
+    vi.stubEnv("NEXT_PUBLIC_WEDGES", "Java,Python");
+    vi.stubEnv("LEAD_COLLECTION", "MANUAL");
+
+    const currentUser = {
+      name: "test-better",
+      sender: "+115112341234",
+      recipient: "+4915156785678",
+      submittedBets: 0,
+      stage: Stages.VERIFIED_USER,
+    };
+
+    const settings: Settings = {
+      ...settingsFromEnv(),
+      wedges: ["Rust"],
+    };
+
+    const response = await generateResponse(currentUser, undefined, {
+      messageContent: "I'd like to bet on Rust",
+      attendeesMap: {
+        syncMapItems: () => ({
+          update: async (data: any) => data,
+        }),
+      },
+      betsDoc: {
+        data: { bets: [], temporaryBlock: false, closed: false },
+        update: async (data: any) => data,
+      },
+      settings,
+    });
+
+    expect(response).toContain(
+      `<?xml version="1.0" encoding="UTF-8"?><Response><Message>🎯 Bet confirmed!`,
+    );
+  });
+
+  test("ctx.settings.maxBetsPerUser overrides a more permissive MAX_BETS_PER_USER env var", async () => {
+    // Env alone would allow this bet (limit 20 > submittedBets 1); the
+    // settings override should be the one enforced.
+    vi.stubEnv("MAX_BETS_PER_USER", "20");
+    vi.stubEnv("LEAD_COLLECTION", "MANUAL");
+
+    const currentUser = {
+      name: "test-better",
+      sender: "+115112341234",
+      recipient: "+4915156785678",
+      submittedBets: 1,
+      stage: Stages.VERIFIED_USER,
+    };
+
+    const settings: Settings = {
+      ...settingsFromEnv(),
+      wedges: ["Java", "Python"],
+      maxBetsPerUser: 1,
+    };
+
+    const response = await generateResponse(currentUser, undefined, {
+      messageContent: "I'd like to bet on Java",
+      attendeesMap: {},
+      betsDoc: {
+        data: { bets: [], temporaryBlock: false, closed: false },
+      },
+      settings,
+    });
+
+    expect(response).toContain(
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Response><Message>You've reached the maximum number of bets for this session!",
+    );
+  });
+
+  test("ctx.settings.offeredPrizes overrides the OFFERED_PRIZES env var for a returning winner", async () => {
+    // Env says "big" (raffle-qualification copy); settings override says "small".
+    vi.stubEnv("OFFERED_PRIZES", "big");
+    vi.stubEnv("LEAD_COLLECTION", "MANUAL");
+
+    const currentUser = {
+      name: "test-better",
+      sender: "+115112341234",
+      recipient: "+4915156785678",
+      stage: Stages.WINNER_UNCLAIMED,
+    };
+
+    const settings: Settings = {
+      ...settingsFromEnv(),
+      offeredPrizes: "small",
+    };
+
+    let sentBody = "";
+    await generateResponse(
+      currentUser,
+      {
+        messages: {
+          create: (c: any) => {
+            sentBody = c.body;
+          },
+        },
+      },
+      {
+        messageContent: "Hello",
+        attendeesMap: {},
+        betsDoc: { data: { bets: {}, temporaryBlock: true, closed: false } },
+        settings,
+      },
+    );
+
+    expect(sentBody).toContain(
+      "Congrats, you already won. Stop by the Twilio booth to claim your prize!",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Move wedges, event name, lead-collection mode, offered prizes, small-prize pool, prizes-per-wedge cap, max-bets-per-user, and the QR-code toggle off env-var-only config and into a new Sync `settings` document, editable live at `/settings` (Basic-Auth gated like `/admin`/`/stats`).
- Env vars remain the *defaults* until an admin saves an override at `/settings`; "Reset to environment defaults" reverts. Existing unit tests keep passing unchanged via env-based default parameters threaded through `helper.ts`/`profile-mode.ts`/`qr-mode.ts`.
- Fixes a permission bug where the `settings` Sync doc, when auto-created on first read/write, didn't grant the FRONTEND identity read access — so the wheel screen never picked up saved overrides even though the `/settings` page itself worked fine (server-side calls use the unrestricted API-key client). Now self-heals on the next read/write.
- Adds unit coverage for `settingsFromEnv`/`mergeSettings` and for the Sync-settings override wiring in `handleBets`/`handleWinnerStages`, plus a read-only e2e spec for `/settings` (never clicks Save/Reset, so it can't mutate the real Sync document or destabilize other specs).

## Test plan
- [x] `pnpm vitest` — 63/63 passing
- [x] `pnpm playwright` — all non-skipped specs passing (chromium)
- [x] `tsc --noEmit` — clean (one pre-existing, unrelated failure in `prize-inventory.test.tsx` confirmed via stash-diff against `main`)
- [x] Manually verified: save an override at `/settings`, reload `/`, wheel reflects new wedges/prizes-per-field/hide-QR-code live; "Reset to environment defaults" reverts

🤖 Generated with [Claude Code](https://claude.com/claude-code)